### PR TITLE
[CD-972] RabbitMQ Connector

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,13 +6,13 @@ Please note that this project is released with a [Contributor Code of Conduct](C
 
 We are always thrilled to receive pull requests, and do our best to process them as fast as possible. Not sure if that typo is worth a pull request? Do it! We will appreciate it.
 
-To contribute code or documentation, please submit a [pull request](https://github.com/ibm-messaging/kafka-connect-rabbitmq-sink/pulls).
+To contribute code or documentation, please submit a [pull request](https://github.com/zyston-messaging/kafka-connect-rabbitmq-sink/pulls).
 
 A good way to familiarize yourself with the codebase and contribution process is
-to look for and tackle low-hanging fruit in the [issue tracker](https://github.com/ibm-messaging/kafka-connect-rabbitmq-sink/issues).
+to look for and tackle low-hanging fruit in the [issue tracker](https://github.com/zyston-messaging/kafka-connect-rabbitmq-sink/issues).
 
 ## Create issues...
-If you would like to implement a new feature, please [raise an issue](https://github.com/ibm-messaging/kafka-connect-rabbitmq-sink/issues)
+If you would like to implement a new feature, please [raise an issue](https://github.com/zyston-messaging/kafka-connect-rabbitmq-sink/issues)
 before sending a pull request so the feature can be discussed before you start working on it.
 
 > Note: We appreciate your effort, and want to avoid a situation where a contribution

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,5 +1,9 @@
 # MAINTAINERS
 
+Ken Seal - kseal@zyston.com
+
+## Upstream
+
 Andrew Schofield - andrew_schofield@uk.ibm.com
 Kate Stanley - katheris@uk.ibm.com
 Jerome Boyer - boyerje@us.ibm.com

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The connector is supplied as source code which you can easily build into a JAR f
 1. Clone the repository with the following command:
 
 ```bash
-git@github.com:ibm-messaging/kafka-connect-rabbitmq-source.git
+git@github.com:zyston-messaging/kafka-connect-rabbitmq-source.git
 ```
 
 2. Change directory to the `kafka-connect-mq-source` directory:
@@ -70,7 +70,7 @@ Kafka Connect service by creating a JSON file in the format below:
 {
     "name": "RabbitMQSourceConnector",
     "config": {
-        "connector.class": "com.ibm.eventstreams.connect.rabbitmqsource.RabbitMQSourceConnector",
+        "connector.class": "com.zyston.eventstreams.connect.rabbitmqsource.RabbitMQSourceConnector",
         "tasks.max": "10",
         "kafka.topic" : "kafka_test",
         "rabbitmq.queue" : "rabbitmq_test",
@@ -130,7 +130,7 @@ kafka-console-consumer --topic kafka_test --from-beginning --bootstrap-server 12
 ```
 
 ## Issues and contributions
-For issues relating specifically to this connector, please use the [GitHub issue tracker](https://github.com/ibm-messaging/kafka-connect-jdbc-sink/issues). If you do want to submit a Pull Request related to this connector, please read the [contributing guide](CONTRIBUTING.md) first to understand how to sign your commits.
+For issues relating specifically to this connector, please use the [GitHub issue tracker](https://github.com/zyston-messaging/kafka-connect-jdbc-sink/issues). If you do want to submit a Pull Request related to this connector, please read the [contributing guide](CONTRIBUTING.md) first to understand how to sign your commits.
 
 
 ## License

--- a/config/connect-distributed.properties
+++ b/config/connect-distributed.properties
@@ -29,8 +29,8 @@ group.id=connect-cluster
 # need to configure these based on the format they want their data in when loaded from or stored into Kafka
 #key.converter=org.apache.kafka.connect.json.JsonConverter
 #value.converter=org.apache.kafka.connect.json.JsonConverter
-key.converter=com.ibm.eventstreams.connect.avroconverter.AvroConverter
-value.converter=com.ibm.eventstreams.connect.avroconverter.AvroConverter
+key.converter=com.zyston.eventstreams.connect.avroconverter.AvroConverter
+value.converter=com.zyston.eventstreams.connect.avroconverter.AvroConverter
 # Converter-specific settings can be passed in by prefixing the Converter's setting with the converter we want to apply
 # it to
 key.converter.schemas.enable=false

--- a/config/connect-standalone.properties
+++ b/config/connect-standalone.properties
@@ -18,8 +18,8 @@ bootstrap.servers=localhost:9092
 
 # The converters specify the format of data in Kafka and how to translate it into Connect data. Every Connect user will
 # need to configure these based on the format they want their data in when loaded from or stored into Kafka
-key.converter=com.ibm.eventstreams.connect.avroconverter.AvroConverter
-value.converter=com.ibm.eventstreams.connect.avroconverter.AvroConverter
+key.converter=com.zyston.eventstreams.connect.avroconverter.AvroConverter
+value.converter=com.zyston.eventstreams.connect.avroconverter.AvroConverter
 #key.converter=org.apache.kafka.connect.json.JsonConverter
 #value.converter=org.apache.kafka.connect.json.JsonConverter
 # Converter-specific settings can be passed in by prefixing the Converter's setting with the converter we want to apply

--- a/config/rabbitmq-source.json
+++ b/config/rabbitmq-source.json
@@ -1,7 +1,7 @@
 {
     "name": "RabbitMQSourceConnector",
     "config": {
-        "connector.class": "com.ibm.eventstreams.connect.rabbitmqsource.RabbitMQSourceConnector",
+        "connector.class": "com.zyston.eventstreams.connect.rabbitmqsource.RabbitMQSourceConnector",
         "tasks.max": "10",
         "kafka.topic" : "kafka_test",
         "rabbitmq.queue" : "rabbitmq_test",

--- a/config/rabbitmq-source.properties
+++ b/config/rabbitmq-source.properties
@@ -1,5 +1,5 @@
 name=rabbitmq
-connector.class=com.ibm.eventstreams.connect.rabbitmqsource.RabbitMQSourceConnector
+connector.class=com.zyston.eventstreams.connect.rabbitmqsource.RabbitMQSourceConnector
 
 # You can increase this for higher throughput, but message ordering will be lost
 tasks.max=1

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>11</source>
+                    <target>11</target>
                     <compilerArgument>-Xlint:all</compilerArgument>
                 </configuration>
             </plugin>
@@ -65,10 +65,10 @@
     </build>
 
     <properties>
-        <rabbitmq.version>5.7.1</rabbitmq.version>
-        <kafka.version>2.4.0</kafka.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <rabbitmq.version>5.20.0</rabbitmq.version>
+        <kafka.version>2.7.0</kafka.version>
+        <maven.compiler.source>1.11</maven.compiler.source>
+        <maven.compiler.target>1.11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -4,16 +4,16 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.ibm.eventstreams.connect</groupId>
+    <groupId>com.zyston.eventstreams.connect</groupId>
     <artifactId>kafka-connect-rabbitmq-source</artifactId>
     <packaging>jar</packaging>
     <version>1.0-SNAPSHOT</version>
     <name>kafka-connect-rabbitmq-source</name>
     <organization>
-        <name>IBM Corporation</name>
-        <url>http://ibm.com</url>
+        <name>Zyston</name>
+        <url>http://zyston.com</url>
     </organization>
-    <url>http://ibm.com</url>
+    <url>http://zyston.com</url>
     <description>
         A Kafka Connect connector for copying data from RabbitMQ into Apache Kafka.
     </description>
@@ -50,7 +50,7 @@
                             <archive>
                                 <manifest>
                                     <mainClass>
-                                        com.ibm.eventstreams.connect.rabbitmqsource.RabbitMQSourceConnector
+                                        com.zyston.eventstreams.connect.rabbitmqsource.RabbitMQSourceConnector
                                     </mainClass>
                                 </manifest>
                             </archive>

--- a/pom.xml
+++ b/pom.xml
@@ -66,9 +66,10 @@
 
     <properties>
         <rabbitmq.version>5.20.0</rabbitmq.version>
-        <kafka.version>2.7.0</kafka.version>
+        <kafka.version>2.7.1</kafka.version>
         <maven.compiler.source>1.11</maven.compiler.source>
         <maven.compiler.target>1.11</maven.compiler.target>
+        <jackson.version>2.16.0</jackson.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -95,6 +96,11 @@
             <groupId>com.google.collections</groupId>
             <artifactId>google-collections</artifactId>
             <version>1.0-rc2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/ibm/eventstreams/connect/rabbitmqsource/sourcerecord/RabbitMQSourceRecordFactory.java
+++ b/src/main/java/com/ibm/eventstreams/connect/rabbitmqsource/sourcerecord/RabbitMQSourceRecordFactory.java
@@ -87,8 +87,8 @@ public class RabbitMQSourceRecordFactory {
 
     public SourceRecord makeSourceRecord(String consumerTag, Envelope envelope, AMQP.BasicProperties basicProperties, byte[] bytes) {
         final String topic = this.config.kafkaTopic;
-        final Map<String, ?> sourcePartition = ImmutableMap.of(EnvelopeSchema.FIELD_ROUTINGKEY, envelope.getRoutingKey());
-        final Map<String, ?> sourceOffset = ImmutableMap.of(EnvelopeSchema.FIELD_DELIVERYTAG, envelope.getDeliveryTag());
+        final Map<String, ?> sourcePartition = Collections.singletonMap(EnvelopeSchema.FIELD_ROUTINGKEY, envelope.getRoutingKey());
+        final Map<String, ?> sourceOffset = Collections.singletonMap(EnvelopeSchema.FIELD_DELIVERYTAG, envelope.getDeliveryTag());
 
         Object key = null;
         if (basicProperties.getHeaders() != null){

--- a/src/main/java/com/zyston/eventstreams/connect/rabbitmqsource/ConnectConsumer.java
+++ b/src/main/java/com/zyston/eventstreams/connect/rabbitmqsource/ConnectConsumer.java
@@ -1,8 +1,8 @@
-package com.ibm.eventstreams.connect.rabbitmqsource;
+package com.zyston.eventstreams.connect.rabbitmqsource;
 
-import com.ibm.eventstreams.connect.rabbitmqsource.config.RabbitMQSourceConnectorConfig;
-import com.ibm.eventstreams.connect.rabbitmqsource.sourcerecord.RabbitMQSourceRecordFactory;
-import com.ibm.eventstreams.connect.rabbitmqsource.sourcerecord.SourceRecordConcurrentLinkedQueue;
+import com.zyston.eventstreams.connect.rabbitmqsource.config.RabbitMQSourceConnectorConfig;
+import com.zyston.eventstreams.connect.rabbitmqsource.sourcerecord.RabbitMQSourceRecordFactory;
+import com.zyston.eventstreams.connect.rabbitmqsource.sourcerecord.SourceRecordConcurrentLinkedQueue;
 
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Consumer;

--- a/src/main/java/com/zyston/eventstreams/connect/rabbitmqsource/ConnectConsumer.java
+++ b/src/main/java/com/zyston/eventstreams/connect/rabbitmqsource/ConnectConsumer.java
@@ -83,6 +83,8 @@ class ConnectConsumer implements Consumer {
      */
     @Override public void handleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties basicProperties, byte[] bytes) throws IOException {
         log.trace("handleDelivery({})", consumerTag);
+        log.trace("Envelope: {}", envelope);
+        log.trace("Basic Properties: {}", basicProperties);
 
         SourceRecord sourceRecord = this.rabbitMQSourceRecordFactory.makeSourceRecord(consumerTag, envelope, basicProperties, bytes);
         this.records.add(sourceRecord);

--- a/src/main/java/com/zyston/eventstreams/connect/rabbitmqsource/RabbitMQSourceConnector.java
+++ b/src/main/java/com/zyston/eventstreams/connect/rabbitmqsource/RabbitMQSourceConnector.java
@@ -1,6 +1,6 @@
-package com.ibm.eventstreams.connect.rabbitmqsource;
+package com.zyston.eventstreams.connect.rabbitmqsource;
 
-import com.ibm.eventstreams.connect.rabbitmqsource.config.RabbitMQSourceConnectorConfig;
+import com.zyston.eventstreams.connect.rabbitmqsource.config.RabbitMQSourceConnectorConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.source.SourceConnector;

--- a/src/main/java/com/zyston/eventstreams/connect/rabbitmqsource/RabbitMQSourceTask.java
+++ b/src/main/java/com/zyston/eventstreams/connect/rabbitmqsource/RabbitMQSourceTask.java
@@ -1,8 +1,8 @@
-package com.ibm.eventstreams.connect.rabbitmqsource;
+package com.zyston.eventstreams.connect.rabbitmqsource;
 
-import com.ibm.eventstreams.connect.rabbitmqsource.config.RabbitMQSourceConnectorConfig;
-import com.ibm.eventstreams.connect.rabbitmqsource.schema.EnvelopeSchema;
-import com.ibm.eventstreams.connect.rabbitmqsource.sourcerecord.SourceRecordConcurrentLinkedQueue;
+import com.zyston.eventstreams.connect.rabbitmqsource.config.RabbitMQSourceConnectorConfig;
+import com.zyston.eventstreams.connect.rabbitmqsource.schema.EnvelopeSchema;
+import com.zyston.eventstreams.connect.rabbitmqsource.sourcerecord.SourceRecordConcurrentLinkedQueue;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/main/java/com/zyston/eventstreams/connect/rabbitmqsource/config/RabbitMQConnectorConfig.java
+++ b/src/main/java/com/zyston/eventstreams/connect/rabbitmqsource/config/RabbitMQConnectorConfig.java
@@ -1,4 +1,4 @@
-package com.ibm.eventstreams.connect.rabbitmqsource.config;
+package com.zyston.eventstreams.connect.rabbitmqsource.config;
 
 import com.rabbitmq.client.ConnectionFactory;
 import org.apache.kafka.common.config.AbstractConfig;

--- a/src/main/java/com/zyston/eventstreams/connect/rabbitmqsource/config/RabbitMQSourceConnectorConfig.java
+++ b/src/main/java/com/zyston/eventstreams/connect/rabbitmqsource/config/RabbitMQSourceConnectorConfig.java
@@ -1,4 +1,4 @@
-package com.ibm.eventstreams.connect.rabbitmqsource.config;
+package com.zyston.eventstreams.connect.rabbitmqsource.config;
 
 import org.apache.kafka.common.config.ConfigDef;
 

--- a/src/main/java/com/zyston/eventstreams/connect/rabbitmqsource/schema/BasicPropertiesSchema.java
+++ b/src/main/java/com/zyston/eventstreams/connect/rabbitmqsource/schema/BasicPropertiesSchema.java
@@ -1,4 +1,4 @@
-package com.ibm.eventstreams.connect.rabbitmqsource.schema;
+package com.zyston.eventstreams.connect.rabbitmqsource.schema;
 
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;

--- a/src/main/java/com/zyston/eventstreams/connect/rabbitmqsource/schema/EnvelopeSchema.java
+++ b/src/main/java/com/zyston/eventstreams/connect/rabbitmqsource/schema/EnvelopeSchema.java
@@ -1,4 +1,4 @@
-package com.ibm.eventstreams.connect.rabbitmqsource.schema;
+package com.zyston.eventstreams.connect.rabbitmqsource.schema;
 
 import com.rabbitmq.client.Envelope;
 import org.apache.kafka.connect.data.Schema;

--- a/src/main/java/com/zyston/eventstreams/connect/rabbitmqsource/schema/HeaderSchema.java
+++ b/src/main/java/com/zyston/eventstreams/connect/rabbitmqsource/schema/HeaderSchema.java
@@ -1,4 +1,4 @@
-package com.ibm.eventstreams.connect.rabbitmqsource.schema;
+package com.zyston.eventstreams.connect.rabbitmqsource.schema;
 
 import com.google.common.collect.ImmutableMap;
 import com.rabbitmq.client.BasicProperties;

--- a/src/main/java/com/zyston/eventstreams/connect/rabbitmqsource/schema/KeySchema.java
+++ b/src/main/java/com/zyston/eventstreams/connect/rabbitmqsource/schema/KeySchema.java
@@ -1,4 +1,4 @@
-package com.ibm.eventstreams.connect.rabbitmqsource.schema;
+package com.zyston.eventstreams.connect.rabbitmqsource.schema;
 
 public class KeySchema {
     public static final String KEY = "keyValue";

--- a/src/main/java/com/zyston/eventstreams/connect/rabbitmqsource/schema/ValueSchema.java
+++ b/src/main/java/com/zyston/eventstreams/connect/rabbitmqsource/schema/ValueSchema.java
@@ -1,4 +1,4 @@
-package com.ibm.eventstreams.connect.rabbitmqsource.schema;
+package com.zyston.eventstreams.connect.rabbitmqsource.schema;
 
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Envelope;

--- a/src/main/java/com/zyston/eventstreams/connect/rabbitmqsource/schema/ZystonEventSchema.java
+++ b/src/main/java/com/zyston/eventstreams/connect/rabbitmqsource/schema/ZystonEventSchema.java
@@ -1,0 +1,35 @@
+package com.zyston.eventstreams.connect.rabbitmqsource.schema;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+
+public class ZystonEventSchema {
+
+    public static final String FIELD_MESSAGE_ID = "event_id";
+    public static final String FIELD_MESSAGE_TIMESTAMP = "timestamp";
+    public static final String FIELD_MESSAGE_PAYLOAD = "payload";
+    public static final String FIELD_MESSAGE_COMMAND_ID = "command_id";
+    public static final String FIELD_MESSAGE_COMMENT = "comment";
+
+    static final Schema SCHEMA = SchemaBuilder.struct()
+            .name("com.zyston.Event")
+            .doc("Zyston Event RabbitMQ Payload")
+            .field(FIELD_MESSAGE_ID, Schema.STRING_SCHEMA)
+            .field(FIELD_MESSAGE_TIMESTAMP, Schema.STRING_SCHEMA)
+            .field(FIELD_MESSAGE_COMMAND_ID, Schema.STRING_SCHEMA)
+            .field(FIELD_MESSAGE_COMMENT, Schema.OPTIONAL_STRING_SCHEMA)
+            .field(FIELD_MESSAGE_PAYLOAD, SchemaBuilder.string().build())
+            .build();
+
+    public static Struct toStruct(JsonNode zystonEvent, String payload) {
+        return new Struct(SCHEMA)
+                .put(FIELD_MESSAGE_ID, zystonEvent.get(FIELD_MESSAGE_ID).asText())
+                .put(FIELD_MESSAGE_TIMESTAMP, zystonEvent.get(FIELD_MESSAGE_TIMESTAMP).asText())
+                .put(FIELD_MESSAGE_COMMAND_ID, zystonEvent.get(FIELD_MESSAGE_COMMAND_ID).asText())
+                .put(FIELD_MESSAGE_COMMENT, zystonEvent.get(FIELD_MESSAGE_COMMENT).asText())
+                .put(FIELD_MESSAGE_PAYLOAD, payload);
+    }
+}

--- a/src/main/java/com/zyston/eventstreams/connect/rabbitmqsource/sourcerecord/RabbitMQSourceRecordFactory.java
+++ b/src/main/java/com/zyston/eventstreams/connect/rabbitmqsource/sourcerecord/RabbitMQSourceRecordFactory.java
@@ -1,10 +1,9 @@
-package com.ibm.eventstreams.connect.rabbitmqsource.sourcerecord;
+package com.zyston.eventstreams.connect.rabbitmqsource.sourcerecord;
 
-import com.google.common.collect.ImmutableMap;
-import com.ibm.eventstreams.connect.rabbitmqsource.config.RabbitMQSourceConnectorConfig;
-import com.ibm.eventstreams.connect.rabbitmqsource.schema.EnvelopeSchema;
-import com.ibm.eventstreams.connect.rabbitmqsource.schema.KeySchema;
-import com.ibm.eventstreams.connect.rabbitmqsource.schema.ValueSchema;
+import com.zyston.eventstreams.connect.rabbitmqsource.config.RabbitMQSourceConnectorConfig;
+import com.zyston.eventstreams.connect.rabbitmqsource.schema.EnvelopeSchema;
+import com.zyston.eventstreams.connect.rabbitmqsource.schema.KeySchema;
+import com.zyston.eventstreams.connect.rabbitmqsource.schema.ValueSchema;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Envelope;
 import com.rabbitmq.client.LongString;

--- a/src/main/java/com/zyston/eventstreams/connect/rabbitmqsource/sourcerecord/SourceRecordConcurrentLinkedQueue.java
+++ b/src/main/java/com/zyston/eventstreams/connect/rabbitmqsource/sourcerecord/SourceRecordConcurrentLinkedQueue.java
@@ -1,4 +1,4 @@
-package com.ibm.eventstreams.connect.rabbitmqsource.sourcerecord;
+package com.zyston.eventstreams.connect.rabbitmqsource.sourcerecord;
 
 import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;


### PR DESCRIPTION
Changes:
- forked https://github.com/ibm-messaging/kafka-connect-rabbitmq-source
- Renamed namespace from `ibm` to `zyston`
- Upgraded Kafka version to match MSK
- Upgraded to Java 11
- Expanded AMQP method `basicConsume` to use `x-stream-offset`
- Added code to extract offsets from Kafka on restart
- Parse ZystonEvent as Kafka Connect Schema

Schema Registry Example:
```
{
  "type": "object",
  "title": "com.zyston.Event",
  "description": "Zyston Event RabbitMQ Payload",
  "properties": {
    "command_id": {
      "type": "string",
      "connect.index": 3
    },
    "event_id": {
      "type": "string",
      "connect.index": 0
    },
    "payload": {
      "type": "string",
      "connect.index": 2
    },
    "comment": {
      "connect.index": 4,
      "oneOf": [
        {
          "type": "null"
        },
        {
          "type": "string"
        }
      ]
    },
    "timestamp": {
      "type": "string",
      "connect.index": 1
    }
  }
}

```

Example Parsed RabbitMQ Event:
```
{
  "event_id": "1cbf44a0-bd53-49e6-b63b-04896cdf8a28",
  "timestamp": "2024-04-08T16:33:23.876492Z",
  "command_id": "3d3ea422-d528-4206-9a2b-fade5b793cc4",
  "comment": "null",
  "payload": "{\"organization_created\":{\"v1\":{\"organization_id\":\"8b54678d-5180-4a6c-bb25-e4c4d1aa3706\",\"name\":\"test-org-3\"}}}"
}

```